### PR TITLE
Bump rumdl-pre-commit from v0.0.143 to v0.0.153

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: "locales"
       - id: trailing-whitespace
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.0.143
+    rev: v0.0.153
     hooks:
       - id: rumdl
         args: [--force-exclude, --fix]


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.0.143 to v0.0.153 and ran the update against the repo.