### PR TITLE
Get zh_CN locale right

### DIFF
--- a/docs/mkdocs.zh_CN.yml
+++ b/docs/mkdocs.zh_CN.yml
@@ -4,7 +4,7 @@ site_url: https://tutorial.beeware.org/zh_CN
 docs_dir: zh_CN
 
 theme:
-  language: zh-Hant
+  language: zh
 
 extra:
   translation_type: machine


### PR DESCRIPTION
zh_CN is tracked as zh according to https://github.com/squidfunk/mkdocs-material/blob/c68fac7fb3071fa4f45cc823e2ca2ea82fd67b43/src/templates/partials/languages/zh.html

I was wondering why the new docs was rendering in zh_TW typography in zh_CN... turns out it was this.
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
