### PR TITLE
Dependabot, pyproject.toml, style guide fix.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,20 @@
-
 version: 2
+
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      # Check for updates on the first Sunday of every month, 8PM UTC
+      interval: "cron"
+      cronjob: "0 20 * * sun#1"
+    assignees: ["housekeeping"]
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      # Check for updates on Sunday, 8PM UTC
-      interval: "weekly"
-      day: "sunday"
-      time: "20:00"
+    patterns: ["*"]
+    multi_ecosystem_group: "dependencies"
 
   - package-ecosystem: "pip"
     directory: "/"
-    schedule:
-      # Check for updates on Sunday, 8PM UTC
-      interval: "weekly"
-      day: "sunday"
-      time: "20:00"
+    patterns: ["*"]
+    multi_ecosystem_group: "dependencies"

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -2,7 +2,7 @@ name: Update pre-commit
 
 on:
   schedule:
-    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
+    - cron: "0 20 * * SUN#1"  # First Sunday of the month @ 2000 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -29,15 +29,14 @@ jobs:
           python-version: "3.X"
           cache: pip
           cache-dependency-path: |
-            requirements.dev.txt
-            requirements.docs.txt
+            pyproject.toml
             .pre-commit-config.yaml
 
       - name: Update pip
         run: python -m pip install -U pip
 
       - name: Install tox
-        run: python -m pip install -r requirements.dev.txt
+        run: python -m pip install --group 'dev'
 
       - name: Configure git
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,11 @@ build:
     # Docs are always built on Python 3.12. See also the tox config.
     python: "3.12"
   jobs:
+    post_checkout:
+      - git fetch --unshallow
     pre_install:
-      - python -m pip install -r requirements.dev.txt
+      - python -m pip install --upgrade pip
+      - python -m pip install --group 'tox-uv'
     pre_build:
       - python -m tox -e docs-lint
     build:

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -8,6 +8,9 @@ respect-gitignore = true
 # MD014: Forces commands in codeblocks to show output
 disable = ["MD014",]
 
+[per-file-ignores]
+"docs/en/how-to/style-guide.md" = ["MD041"]
+
 [MD026]  # Remove punctuation at the end of headings
 punctuation = ",;:"
 

--- a/docs/en/how-to/style-guide.md
+++ b/docs/en/how-to/style-guide.md
@@ -1,1 +1,1 @@
--8<- "style_guide.md" <!-- rumdl-disable-line MD041 -->
+-8<- "style_guide.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[dependency-groups]
+pre-commit = [
+    "pre-commit == 4.3.0",
+]
+
+tox-uv = [
+    "tox-uv == 1.28.0",
+]
+
+dev = [
+    "wlc == 1.16.1",
+    {include-group = "pre-commit"},
+    {include-group = "tox-uv"},
+]
+
+docs = [
+    "beeware-docs-tools @ git+https://github.com/beeware/beeware-docs-tools",
+]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,0 @@
-# Docs are always built on a specific Python version; see RTD and tox config files.
-tox-uv == 1.29.0
-pre-commit == 4.3.0
-wlc==1.16.1

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,2 +1,0 @@
-# Docs are always built on a specific Python version; see RTD and tox config files.
-beeware-docs-tools @ git+https://github.com/beeware/beeware-docs-tools

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ base_python = py312
 skip_install = true
 passenv =
     DEEPL_API_KEY
-deps =
-    -r {tox_root}/requirements.docs.txt
+dependency_groups = docs
 commands:
     !lint-!all-!translate-!live-!en-!de-!es-!fr-!it-!pt-!zh-cn-!zh-tw : build_md_translations {posargs} en
     translate : build_pot_translations


### PR DESCRIPTION
* Updates Dependabot config to run on the first Sunday of every month at 20:00UTC, grouping all updates to a single PR, and assigning the `housekeeping` team to the PR.
* Updates pre-commit update config to run on the first Sunday of every month at 20:00UTC.
* Shifts from `requirements.*.txt` to `pyproject.toml` for dependencies.
* Shifts all dependency reference to use dependency groups.
* Fixes an issue with the `rumdl` disable affecting the style guide Snippets inclusion.

Fixes #25 

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
