### PR TITLE
docs: update 'Clone or Download' to 'Code' in contribution tutorial.

### DIFF
--- a/docs/en/how-to/contribute.md
+++ b/docs/en/how-to/contribute.md
@@ -72,7 +72,7 @@ Your prompt should now have a `(.venv)` prefix in front of it.
 
 For updates to BeeWare documentation:
 
-Next, go to [the BeeWare Tutorial page on GitHub](https://github.com/beeware/beeware-tutorial), fork the repository into your own account, and then clone a copy of that repository onto your computer by clicking on "Clone or Download". If you have the GitHub desktop application installed on your computer, you can select "Open in Desktop"; otherwise, copy the URL provided, and use it to clone using the command line:
+Next, go to [the BeeWare Tutorial page on GitHub](https://github.com/beeware/beeware-tutorial), fork the repository into your own account, and then clone a copy of that repository onto your computer by clicking on "Code". If you have the GitHub desktop application installed on your computer, you can select "Open in Desktop"; otherwise, copy the URL provided, and use it to clone using the command line:
 
 /// tab | macOS
 


### PR DESCRIPTION
An update to the contribution tutorial documentation was made addressing a GUI change on GitHub.
The "Clone or Download" button label has changed on GitHub to "Code".

Fixes #20 


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
