### PR TITLE
Schedule pre-commit autoupdate for the first Sunday of every month.

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -2,7 +2,10 @@ name: Update pre-commit
 
 on:
   schedule:
-    - cron: "0 20 * * SUN#1"  # First Sunday of the month @ 2000 UTC
+    - cron: "0 20 1-7 * */7"  # First Sunday of the month @ 2000 UTC
+      # Reading this expression: At 20:00 on every day-of-month from 1 through 7 if
+      # it's on every 7th day-of-week, i.e. any one of the first seven days of the
+      # month as long as it is a Sunday.
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This restricts the days of the month to 1-7, and because of how cron interprets the `*`, it is essentially saying "On days 1-7 that are *also* Sunday", which amounts to the first Sunday of every month. 

This apparently uses a "classic cron" feature, that not every scheduler is likely to support. So this may also turn out to be invalid.

In theory.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct