### PR TITLE
issue  #46 module reference error in french translation of tutorial-7

### DIFF
--- a/docs/locales/fr/translations.po
+++ b/docs/locales/fr/translations.po
@@ -4545,14 +4545,14 @@ msgstr ""
 #, fuzzy
 msgid "A specific library version (e.g., `\"faker==37.3.0\"`);"
 msgstr ""
-"Une version spécifique de la bibliothèque (par exemple, `\"httpx==0.19.0\"`) "
+"Une version spécifique de la bibliothèque (par exemple, `\"faker==37.3.0\"`) "
 ";"
 
 #: docs/en/tutorial/tutorial-7.md:480
 #, fuzzy
 msgid "A range of library versions (e.g., `\"faker>=37\"`);"
 msgstr ""
-"Une gamme de versions de la bibliothèque (par exemple, `\"httpx>=0.19\"`) ;"
+"Une gamme de versions de la bibliothèque (par exemple, `\"faker>=37\"`) ;"
 
 #: docs/en/tutorial/tutorial-7.md:481
 #, fuzzy
@@ -4560,8 +4560,7 @@ msgid ""
 "A path to a git repository (e.g., `\"git+https://github.com/joke2k/faker/\"`)"
 "; or"
 msgstr ""
-"Un chemin vers un dépôt git (par exemple, `\"git+https://github.com/encode/"
-"httpx\"`) ; ou"
+"Un chemin vers un dépôt git (par exemple, `\"git+https://github.com/joke2k/faker/\"`) ; ou"
 
 #: docs/en/tutorial/tutorial-7.md:482
 #, fuzzy


### PR DESCRIPTION
<!--- Describe your changes in detail -->
bad references to httpx module have been replaced by faker module references in tutorial-7
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

issue #46 that I've done this day
I think it's better to fix it with this pull request (my first one in github !)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
