### PR TITLE
Relax restriction on Python 3.14 on Windows.

### DIFF
--- a/docs/en/tutorial/tutorial-0.md
+++ b/docs/en/tutorial/tutorial-0.md
@@ -38,7 +38,7 @@ Support for Raspberry Pi is limited at this time.
 
 /// tab | Windows
 
-If you're on Windows, you can get the official installer from [the Python website](https://www.python.org/downloads). You can use any version of Python from 3.10 to 3.13 (although you should avoid alphas, betas and release candidates). We strongly recommend using Python 3.13.
+If you're on Windows, you can get the official installer from [the Python website](https://www.python.org/downloads). You can use any version of Python from 3.10 to 3.14 (although you should avoid alphas, betas and release candidates). We strongly recommend using Python 3.13 or newer.
 
 Support for Windows on ARM64 is limited at this time.
 


### PR DESCRIPTION
Python.net has released v3.1.0, which is now compatible with Python 3.14, so we can drop that restriction.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
