### PR TITLE
Revert "Mention about WSL 2 setup in Windows section."

### DIFF
--- a/docs/en/tutorial/tutorial-0.md
+++ b/docs/en/tutorial/tutorial-0.md
@@ -103,20 +103,6 @@ Building BeeWare apps on Windows requires:
 
 After installing these tools, you should ensure you restart any terminal sessions. Windows will only expose newly installed tools terminals started *after* the install has completed.
 
-/// admonition | WSL 2
-
-If you are using WSL 2, just follow the Linux instructions for your distribution.
-To work with GUI projects or the Android emulator, open the `C:\Users\%USERNAME%\.wslconfig` file and make sure that:
-
-```ini
-[wsl2]
-guiApplications=true
-```
-
-is set to true. Afterward, shut down WSL using `wsl --shutdown` in the Windows command prompt and restart it.
-
-///
-
 ///
 
 ## Set up a virtual environment

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -84,5 +84,4 @@ UI
 uv
 verbing
 Weblate
-WSL
 Xcode


### PR DESCRIPTION
Reverts beeware/beeware-tutorial#85

I'm reverting this for two reasons:

1. This is BeeWare's tutorial. It's the first point of contact someone has with BeeWare; that means the instructions need to be curated, intentional, have as few "options" as possible, and show off the best side of the tools being demonstrated. If the user is on Windows, that means using the Winforms backend, because that's what a "native application" looks like on Windows.

2. There's evidently some issues around WSL2 support (see beeware/toga#4571) - while those are lingering, I'm especially  hesitant to recommend WSL2 usage in the tutorial.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
