### PR TITLE
Fix Chinese heading translation in MkDocs config

### DIFF
--- a/docs/mkdocs.zh_CN.yml
+++ b/docs/mkdocs.zh_CN.yml
@@ -15,4 +15,4 @@ extra:
     Community: 社区
     Contributing: 贡献
     News: 新闻
-    Sponsor: 赞助商
+    Sponsor: 赞助


### PR DESCRIPTION
Changes Sponsor in zh_CN MkDocs config to use 赞助 instead of 赞助商.  This mirrors the change in the header translation I made on Weblate.

Rationale:  赞助商 means Sponsor in terms of a noun (i.e. referring to people who sposored), and 赞助 is the verb Sponsor (i.e. to support an organization financially.)

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
